### PR TITLE
Document the .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
    npm install yarn -g
    ```
 
-3. Finally, using Yarn, install the ETMobile dependencies:
+3. Using Yarn, install the ETMobile dependencies:
 
    ```sh
    yarn
@@ -41,6 +41,12 @@
    You may re-run this command in the future to install any new or updated
    dependencies (which will show up as "Module not found: ...") error messages
    in the application.
+
+4. Create a copy of the default environment file:
+
+   ```sh
+   cp .env.example .env
+   ```
 
 You may now run the development version of ETMobile with `npm start`. The tests
 can be performed with `npm test` and `npm run coverage`.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "axios": "^0.15.2",
     "babel-cli": "^6.18.0",
+    "dotenv": "^2.0.0",
     "enzyme": "^2.4.1",
     "fetch-mock": "^5.5.0",
     "gh-pages": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "coverage": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
     "build-answers": "babel-node --presets es2015 scripts/buildAnswers.js",
-    "deploy": "gh-pages -d build"
+    "deploy": "[ -f .env ] && gh-pages -d build || echo 'No .env file found'"
   }
 }

--- a/scripts/buildAnswers.js
+++ b/scripts/buildAnswers.js
@@ -1,13 +1,22 @@
 /* eslint no-console: 0 */
 /* eslint no-param-reassign: 0 */
+/* eslint import/no-extraneous-dependencies: 0 */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import axios from 'axios';
 import fs from 'fs';
+import process from 'process';
+import dotenv from 'dotenv';
 
 import staticChoices from '../src/data/choices';
 
-const endpoint = 'https://beta-engine.energytransitionmodel.com';
+dotenv.config({ silent: true });
+
+const endpoint = process.env.REACT_APP_ETENGINE_URL;
+
+if (!endpoint) {
+  console.error('No REACT_APP_ETENGINE_URL defined; do you have a .env file?');
+  process.exit(1);
+}
 
 /**
  * Template string tag which removes leading space from each line in the string.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,7 +1937,7 @@ dot-case@^2.1.0:
   dependencies:
     no-case "^2.2.0"
 
-dotenv@2.0.0:
+dotenv, dotenv@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
 


### PR DESCRIPTION
Adds a step the the install instructions detailing that a developer must create a copy of the `.env` file. Failing to do so will result in deployed versions of the application having an incorrect ETEngine hostname. I updated the deploy task to assert that the file exists.

Assigning @dennisschoenmakers because I suspect you might need to perform this step on your own machine. 😉 

```sh
cp .env.example .env
```