### PR TITLE
Prevent multiple choice selection

### DIFF
--- a/src/components/Chooser.js
+++ b/src/components/Chooser.js
@@ -14,9 +14,14 @@ const Chooser = (props) => {
     ...(props.classNames || {})
   });
 
+  const onClick = (event) => {
+    event.preventDefault();
+    props.onClick(props.index);
+  };
+
   return (
     <button
-      onClick={() => props.onClick(props.index)}
+      onClick={onClick}
       disabled={props.selectedIndex !== null}
       className={classNames(classes)}
     >

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -11,6 +11,10 @@ class Question extends React.Component {
   }
 
   onChoiceSelected(choiceIndex) {
+    if (this.state.choice !== null) {
+      return;
+    }
+
     const choice = this.props.choices[choiceIndex];
 
     this.setState({ choice: choiceIndex });

--- a/src/components/__tests__/Chooser.test.js
+++ b/src/components/__tests__/Chooser.test.js
@@ -81,12 +81,14 @@ it('renders an unchosen, incorrect button', () => {
 
 it('binds the onClick listener to the buttons', () => {
   const onClick = jest.fn();
+  const preventDefault = jest.fn();
 
   const wrapper = shallow(
     <Chooser onClick={onClick} index={0}>Hello</Chooser>
   );
 
-  wrapper.simulate('click');
+  wrapper.simulate('click', { preventDefault });
 
   expect(onClick).toHaveBeenCalled();
+  expect(preventDefault).toHaveBeenCalled();
 });

--- a/src/components/__tests__/Question.test.js
+++ b/src/components/__tests__/Question.test.js
@@ -99,6 +99,25 @@ it('renders a correctly-chosen question button', () => {
   expect(wrapper.find('button.incorrect').length).toEqual(0);
 });
 
+it('does not permit answering more than once', () => {
+  const onChoiceMade = jest.fn();
+
+  const wrapper = mountWithIntl(
+    <Question
+      code="abcdef"
+      name="My Question"
+      description={{ __html: 'Hello there' }}
+      choices={choicesFixture()}
+      onChoiceMade={onChoiceMade}
+    />
+  );
+
+  wrapper.instance().onChoiceSelected(0);
+  wrapper.instance().onChoiceSelected(0);
+
+  expect(onChoiceMade).toHaveBeenCalledTimes(1);
+});
+
 it('renders an incorrectly-chosen question button', () => {
   const wrapper = mountWithIntl(
     <Question


### PR DESCRIPTION
* Prevents a visitor from selecting a choice multiple times during transition to the next question.
* Prevents browser default action when tapping a choice button; fixes zooming on iOS 10.