### PR TITLE
Add summary of previous question to each page

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -7,6 +7,7 @@ import Header from '../components/Header';
 import Question from '../components/Question';
 import Summary from '../components/Summary';
 import ProgressBar from '../components/ProgressBar';
+import PreviousSummary from '../components/PreviousSummary';
 import { sparseChoiceShape } from '../components/Choice';
 
 import authenticate from '../utils/authenticate';
@@ -205,6 +206,19 @@ class Game extends React.Component {
         <main className="question-wrapper">
           <ReactCSSTransitionGroup
             component="div"
+            transitionName={{ enter: 'fadeIn', leave: 'fadeOutUp' }}
+            transitionEnterTimeout={1000}
+            transitionLeaveTimeout={1000}
+          >
+            {this.state.answeredQuestions[0] ?
+              <PreviousSummary
+                question={this.state.answeredQuestions[0]}
+                key="previous-summary"
+              /> :
+              null}
+          </ReactCSSTransitionGroup>
+          <ReactCSSTransitionGroup
+            component="div"
             transitionName={{ enter: 'fadeInUp', leave: 'fadeOutUp' }}
             transitionEnterTimeout={1000}
             transitionLeaveTimeout={1000}
@@ -251,12 +265,25 @@ class Game extends React.Component {
             current={this.props.mode.attempts - this.state.attemptsRemaining}
             total={this.props.mode.attempts}
           /> :
-          null }
+          null}
         {content}
       </div>
     );
   }
 }
+
+/*<div className="previous-result">
+  <button>
+    <div className="choice incorrect">-0.15%</div>
+    <div className="divider">?</div>
+    <div className="choice correct selected">-1.50%</div>
+  </button>
+  {this.state.answeredQuestions[0] ?
+    <div className="recap">
+      <QuestionSummary question={this.state.answeredQuestions[0]} />
+    </div> :
+    null}
+</div>*/
 
 Game.defaultProps = { challengeId: null };
 

--- a/src/components/PreviousSummary.js
+++ b/src/components/PreviousSummary.js
@@ -1,0 +1,89 @@
+import React, { PropTypes } from 'react';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
+import classNames from 'classnames';
+
+import Choice from './Choice';
+import QuestionSummary from './QuestionSummary';
+
+/**
+ * Formats a choice delta.
+ */
+const choiceDelta = delta => (
+  <span><FormattedNumber value={Math.round(delta * 100) / 100} />%</span>
+);
+
+/**
+ * Builds the summary containing the CO2 emissions of the two choices.
+ */
+const buildSummary = (choices, onClick, selected) => {
+  const classes = choices.map(choice => classNames({
+    choice: true,
+    selected: choice === selected,
+    correct: choice.isCorrect,
+    incorrect: !choice.isCorrect
+  }));
+
+  return (
+    <button onClick={onClick} className="main-button">
+      <div className={classes[0]}>{choiceDelta(choices[0].delta)}</div>
+      <div className="divider">?</div>
+      <div className={classes[1]}>{choiceDelta(choices[1].delta)}</div>
+    </button>
+  );
+};
+
+/**
+ * A summary of the most recent question answered. Shown in the header to
+ * provide the means for a visitor to recap the reasons for the previous answer
+ * being correct or incorrect.
+ */
+class PreviousSummary extends React.Component {
+  constructor() {
+    super();
+    this.state = { open: false };
+    this.toggle = this.toggle.bind(this);
+  }
+
+  toggle() {
+    this.setState({ open: !this.state.open });
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    const classes = classNames({
+      'animated': true,
+      'previous-result': true,
+      'open': this.state.open
+    });
+
+    const summary = buildSummary(
+      this.props.question.choices, this.toggle, this.props.question.selected
+    );
+
+    return (
+      <div className={classes}>
+        {summary}
+        {this.state.open ?
+          <div>
+            <div className="recap">
+              <QuestionSummary question={this.props.question} />
+              <button onClick={this.toggle} className="close">
+                <FormattedMessage id="summary.hideExplanation" />
+              </button>
+            </div>
+          </div> :
+          null}
+      </div>
+    );
+  }
+}
+
+PreviousSummary.propTypes = {
+  question: PropTypes.shape({
+    choices: PropTypes.arrayOf(Choice.propTypes.choice).isRequired,
+    selected: Choice.propTypes.choice.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default PreviousSummary;

--- a/src/components/__tests__/PreviousSummary.test.js
+++ b/src/components/__tests__/PreviousSummary.test.js
@@ -37,6 +37,16 @@ it('renders a simple summary when closed', () => {
   expect(numbers.at(1).props().value).toEqual(-0.1);
 });
 
+it('toggles display of the explanations', () => {
+  const wrapper = shallow(
+    <PreviousSummary question={stateWithSummaries()} />
+  );
+
+  expect(wrapper.find(QuestionSummary).length).toEqual(0);
+  wrapper.instance().toggle();
+  expect(wrapper.find(QuestionSummary).length).toEqual(1);
+});
+
 it('renders no quesiton summary when closed', () => {
   const wrapper = shallow(
     <PreviousSummary question={stateWithSummaries()} />

--- a/src/components/__tests__/PreviousSummary.test.js
+++ b/src/components/__tests__/PreviousSummary.test.js
@@ -1,0 +1,56 @@
+/* global it expect */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { FormattedNumber } from 'react-intl';
+
+import PreviousSummary from '../PreviousSummary';
+import QuestionSummary from '../QuestionSummary';
+
+const stateWithSummaries = (firstDelta = -1.0, secondDelta = -0.1) => ({
+  name: 'First choice or second choice?',
+  choices: [{
+    icon: 'wind',
+    isCorrect: true,
+    name: 'First choice',
+    description: 'Desc of choice 1',
+    delta: firstDelta
+  }, {
+    icon: 'wind',
+    isCorrect: true,
+    name: 'Second choice',
+    description: 'Desc of choice 2',
+    delta: secondDelta
+  }]
+});
+
+it('renders a simple summary when closed', () => {
+  const wrapper = shallow(
+    <PreviousSummary question={stateWithSummaries()} />
+  );
+
+  expect(wrapper.find('.choice').length).toEqual(2);
+
+  const numbers = wrapper.find(FormattedNumber);
+
+  expect(numbers.at(0).props().value).toEqual(-1.0);
+  expect(numbers.at(1).props().value).toEqual(-0.1);
+});
+
+it('renders no quesiton summary when closed', () => {
+  const wrapper = shallow(
+    <PreviousSummary question={stateWithSummaries()} />
+  );
+
+  expect(wrapper.find(QuestionSummary).length).toEqual(0);
+});
+
+it('renders a quesiton summary when opened', () => {
+  const wrapper = shallow(
+    <PreviousSummary question={stateWithSummaries()} />
+  );
+
+  wrapper.setState({ open: true });
+
+  expect(wrapper.find(QuestionSummary).length).toEqual(1);
+});

--- a/src/data/locales/en/summary.js
+++ b/src/data/locales/en/summary.js
@@ -1,6 +1,7 @@
 export default {
   allCorrect: 'You got all the questions correct!',
   correctWas: 'The correct answer was',
+  hideExplanation: 'Hide explanation',
   numberCorrect: `
     You made {correct, plural,
       =0 {no correct choices!}

--- a/src/data/locales/nl/summary.js
+++ b/src/data/locales/nl/summary.js
@@ -2,6 +2,7 @@
 export default {
   allCorrect: 'Je hebt alle antwoorden goed!',
   correctWas: 'Het goede antwoord was',
+  hideExplanation: 'Verberg uitlen',
   numberCorrect: `
     Je had {correct, plural,
       =0 {geen goede antwoorden}

--- a/src/index.css
+++ b/src/index.css
@@ -186,7 +186,7 @@ h2 {
 }
 
 .question .choice-info img,
-.results .result-item .status img.icon {
+.result-item .status img.icon {
   border: 3px solid white;
   border-radius: 50%;
   box-shadow: 0 0px 0 1px rgba(0, 0, 0, 0.01), 0 1px 0 rgba(0, 0, 0, 0.03);
@@ -346,12 +346,119 @@ button .arrows {
   font-size: 4rem;
 }
 
-.results .result-item {
+.previous-result {
+  padding: 1.5rem 0 0;
+  text-align: center;
+}
+
+.previous-result.disabled {
+  opacity: 0.5;
+}
+
+.previous-result.open {
+  background: linear-gradient(rgba(255, 255, 255, 0), white);
+  border-bottom: 1px solid #d6e1ed;
+  padding-bottom: 1rem;
+}
+
+.previous-result button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin: 0;
+  outline: none;
+  padding: 0;
+  width: 100%;
+}
+
+.previous-result button.main-button {
+    font-size: 0.8125rem;
+}
+
+.previous-result.disabled button {
+  cursor: default;
+}
+
+.previous-result .choice {
+  background: white;
+  border: 2px solid #d6e1ed;
+  border-radius: 3px;
+  color: #41a94f;
+  display: inline-block;
+  padding: 0.25rem 0;
+  width: 40%;
+}
+
+.previous-result.disabled .choice {
+  color: white;
+}
+
+.previous-result .incorrect {
+  color: #dc4545;
+}
+
+.previous-result .choice:first-child {
+  border-right: none;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.previous-result .choice:last-child {
+  border-left: none;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.previous-result .choice.selected {
+  border-color: #5998de;
+}
+
+.previous-result .divider {
+  background: linear-gradient(#5998de, #4488d7);
+  border-radius: 60px;
+  color: #fff;
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
+  margin-top: -0.1875rem;
+  margin-left: -1rem;
+  margin-right: -1rem;
+  padding: 0.5rem 0;
+  position: relative;
+  text-shadow: 0 1px 0 #2760ad;
+  vertical-align: top;
+  width: 2rem;
+  z-index: 2;
+}
+
+.previous-result .recap {
+  border-top: none;
+  margin: 0 1rem;
+  padding-top: 0;
+}
+
+.previous-result .recap .result-item:last-child {
+  margin-bottom: 0;
+}
+
+.previous-result .recap .question-summary {
+  border-bottom: none;
+}
+
+.previous-result .close {
+  border-top: 1px solid #d6e1ed;
+  color: #337cbb;
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  width: auto;
+}
+
+.result-item {
   display: flex;
   margin-bottom: 1rem;
 }
 
-.results .status {
+.result-item .status {
   width: 81px;
 }
 
@@ -369,7 +476,7 @@ button .arrows {
   padding-right: 1rem;
 }
 
-.results .status .change {
+.result-item .status .change {
   background: linear-gradient(#4bb63e, #3aa92f);
   background-clip: padding-box;
   border: 3px solid white;
@@ -383,29 +490,29 @@ button .arrows {
   width: 75px;
 }
 
-.results .status .change.incorrect {
+.result-item .status .change.incorrect {
   background: linear-gradient(#b63e3e, #a92f2f);
 }
 
-.results .info {
+.result-item .info {
   flex: 1;
   padding-left: 1rem;
   text-align: left;
 }
 
-.results .info p {
+.result-item .info p {
   color: #70757b;
 }
 
-.results .info h4 {
+.result-item .info h4 {
   margin-top: 0;
 }
 
-.results .info h4 + p {
+.result-item .info h4 + p {
   margin-top: 0;
 }
 
-.results .info a {
+.result-item .info a {
   color: #3b85c4;
   text-decoration: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -380,12 +380,12 @@ button .arrows {
 }
 
 .previous-result .choice {
-  background: white;
-  border: 2px solid #d6e1ed;
+  background-image: linear-gradient(#57b863, #41a94f);
   border-radius: 3px;
-  color: #41a94f;
+  color: white;
   display: inline-block;
-  padding: 0.25rem 0;
+  padding: 0.375rem 0;
+  text-shadow: 0 1px 0 #268842;
   width: 40%;
 }
 
@@ -394,7 +394,8 @@ button .arrows {
 }
 
 .previous-result .incorrect {
-  color: #dc4545;
+  background: linear-gradient(#dc4545, #b92d2d);
+  text-shadow: 0 1px 0 #961a1a;
 }
 
 .previous-result .choice:first-child {
@@ -416,11 +417,12 @@ button .arrows {
 .previous-result .divider {
   background: linear-gradient(#5998de, #4488d7);
   border-radius: 60px;
+  border: 2px solid #f5f9ff;
   color: #fff;
   display: inline-block;
   font-size: 1rem;
   line-height: 1;
-  margin-top: -0.1875rem;
+  margin-top: -0.325rem;
   margin-left: -1rem;
   margin-right: -1rem;
   padding: 0.5rem 0;


### PR DESCRIPTION
Summarises the previous question. By default shows the CO2 emissions of the two choices. If activated, also shows the reasons for each choice being correct or incorrect.

Screenshots are included below. I don't really the way it looks at all. I think it's completely unintuitive that the numbers shown have anything to do with the previous question. I tried [putting it above the progress bar]((https://cloud.githubusercontent.com/assets/4383/25664630/1f344504-3013-11e7-8949-f88b22bee6a3.png)) – which avoids the sense that it's just "floating" at the top of the page, and perhaps avoids the visitor from thinking that the numbers are connected to the *current* question – but it still doesn't feel right. Which do you prefer?

I know why this feature is needed, but it just feels... bolted on? An afterthought? I don't know what else we can do with it; there's nowhere natural in the UI to put this. Feedback would be much appreciated.

## Actions needed

* If you wish to merge without any changes, please check [this translation](https://github.com/quintel/etmobile/blob/077d83988dec5cf12f3f730a9ea776b5cee66302/src/data/locales/nl/summary.js#L5) before merging. In English it reads "Hide explanation". "Close explanation" would also be okay.

## Screenshots

### First question

![screen shot 2017-05-03 at 15 04 09](https://cloud.githubusercontent.com/assets/4383/25664200/cef8d484-3011-11e7-8a13-9b47ef6a5180.png)

### Subsequent questions

![screen shot 2017-05-03 at 15 04 14](https://cloud.githubusercontent.com/assets/4383/25664208/d6a7baf6-3011-11e7-95e3-25d8af949825.png)

* Correct and incorrect answers are coloured appropriately.
* The player's choice is highlighted with a blue border.

### Expanded (clicked / pressed)

![screen shot 2017-05-03 at 15 04 20](https://cloud.githubusercontent.com/assets/4383/25664218/debb7af2-3011-11e7-9c48-f6f9ced91c53.png)

* Full explanation texts shown with CO<sub>2</sub> emissions.
* Explanations may be closed by pressing the `?` again, or a "Hide explanations" button at the bottom.