### PR TITLE
Authenticate user prior to creating a new challenge

### DIFF
--- a/src/components/NewChallenge.js
+++ b/src/components/NewChallenge.js
@@ -6,6 +6,7 @@ import injectIntl from '../utils/injectIntl';
 
 import Header from './Header';
 
+import authenticate from '../utils/authenticate';
 import randomId from '../utils/randomId';
 import challengeExpiry from '../utils/challengeExpiry';
 
@@ -37,12 +38,14 @@ class NewChallenge extends React.Component {
       const expires = expiryFromSelect(this.expiresField);
       const mode = this.difficultyField.value;
 
-      this.props.base.post(
-        `challenges/${challengeId}`, { data: { name, expires, mode } }
-      ).then(
-        () => this.setState({ challengeId, name }),
-        () => this.setState(this.errorFor('challenges.errors.starting'))
-      );
+      authenticate(this.props.base, () => {
+        this.props.base.post(
+          `challenges/${challengeId}`, { data: { name, expires, mode } }
+        ).then(
+          () => this.setState({ challengeId, name }),
+          () => this.setState(this.errorFor('challenges.errors.starting'))
+        );
+      });
     } else {
       this.setState(this.errorFor('challenges.errors.missingName'));
     }

--- a/src/components/__tests__/NewChallenge.test.js
+++ b/src/components/__tests__/NewChallenge.test.js
@@ -18,7 +18,10 @@ it('render a name field', () => {
 
 it('triggers onSubmit when submitting', () => {
   const promise = Promise.resolve();
-  const base = { post: jest.fn().mockReturnValue(promise) };
+  const base = {
+    post: jest.fn().mockReturnValue(promise),
+    onAuth: cb => cb({ uid: 'abc' })
+  };
 
   const wrapper = mountWithIntl(
     <MemoryRouter initialEntries={['/new-challenge']}>
@@ -62,7 +65,10 @@ it('does not submit if the name is blank', () => {
 
 it('shows an error when the post fails', () => {
   const promise = Promise.reject();
-  const base = { post: jest.fn().mockReturnValue(promise) };
+  const base = {
+    post: jest.fn().mockReturnValue(promise),
+    onAuth: cb => cb({ uid: 'abc' })
+  };
 
   const wrapper = mountWithIntl(
     <NewChallenge base={base} defaultName="Hi" />


### PR DESCRIPTION
Fixes that users who tried to create a new challenge without having played the game would receive an authentication error from Firebase.

Closes #110